### PR TITLE
Feat 3 JPA 양방향 연관 관계 설정

### DIFF
--- a/src/main/java/com/example/toeicwordtest/domain/chapter/entity/Chapter.java
+++ b/src/main/java/com/example/toeicwordtest/domain/chapter/entity/Chapter.java
@@ -11,7 +11,6 @@ import java.util.List;
 @Entity
 @Table(name = "chapter")
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -33,4 +32,35 @@ public class Chapter {
     @OneToMany(mappedBy = "chapter", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<Word> words = new ArrayList<>();
+
+    // == 연관 관계 편의 메서드 == //
+
+    public void addUser(User user) {
+        //  Chapter의 user 필드에 User를 설정
+        if (this.user != user) { // 이미 같은 User라면 아무것도 하지 않음 (무한 루프 방지)
+            // 기존 User와의 관계 끊기 (선택 사항: 양방향 제거 로직) 아마 이런 케이스는 없을거임
+            if (this.user != null) {
+                this.user.getChapters().remove(this);
+            }
+            this.user = user; // 새로운 User로 설정
+        }
+
+        // 2. User의 chapters 컬렉션에 Chapter를 추가 (User.addChapter() 호출)
+        //    이때 User.addChapter() 내부에서 다시 Chapter.setUser()를 호출하지 않도록 방지 로직 필요
+        if (user != null && !user.getChapters().contains(this)) { // User가 아직 이 Chapter를 가지고 있지 않다면
+            //user.getChapters().add(this); // User가 자신의 chapters 컬렉션에 Chapter를 추가
+            user.addChapter(this);
+        }
+    }
+
+
+
+    public void addWord(Word word) {
+        if (word != null && !this.words.contains(word)) {
+            this.words.add(word);
+            if (word.getChapter() != this) {
+                word.setChapter(this);
+            }
+        }
+    }
 }

--- a/src/main/java/com/example/toeicwordtest/domain/user/entity/User.java
+++ b/src/main/java/com/example/toeicwordtest/domain/user/entity/User.java
@@ -47,6 +47,7 @@ public class User {
     private Set<Role> roles = new HashSet<>();
 
     // mappedBy에는 조인할 테이블에서 조인할 객체?의 변수명을 적는거임
+    // (주인이 아닌쪽이 mappedBy를 가짐."니가 가지고 있는 그 외래키 주인이 누구야?->Chapter요" 그래서 Chapter가 주인인거임)
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true,fetch = FetchType.LAZY)
     @Builder.Default // 이게 있어야 빌더 만들때 값을 안넣은 상태에서 get해도 null이 아니라 빈 ArrayList가 나옴
     private List<Chapter> chapters = new ArrayList<>();

--- a/src/main/java/com/example/toeicwordtest/domain/user/entity/User.java
+++ b/src/main/java/com/example/toeicwordtest/domain/user/entity/User.java
@@ -46,7 +46,7 @@ public class User {
     private Set<Role> roles = new HashSet<>();
 
     // mappedBy에는 조인할 테이블에서 조인할 객체?의 변수명을 적는거임
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true,fetch = FetchType.LAZY)
     @Builder.Default
     private List<Chapter> chapters = new ArrayList<>();
 

--- a/src/main/java/com/example/toeicwordtest/domain/user/entity/User.java
+++ b/src/main/java/com/example/toeicwordtest/domain/user/entity/User.java
@@ -5,6 +5,7 @@ import com.example.toeicwordtest.domain.role.entity.Role;
 import com.example.toeicwordtest.domain.wrongnote.entity.WrongNoteEntry;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -14,7 +15,7 @@ import java.util.Set;
 
 @Entity
 @Table(name = "users")
-@Getter @Setter
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -47,10 +48,54 @@ public class User {
 
     // mappedBy에는 조인할 테이블에서 조인할 객체?의 변수명을 적는거임
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true,fetch = FetchType.LAZY)
-    @Builder.Default
+    @Builder.Default // 이게 있어야 빌더 만들때 값을 안넣은 상태에서 get해도 null이 아니라 빈 ArrayList가 나옴
     private List<Chapter> chapters = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Builder.Default // Builder 사용 시 초기화 누락 방지
     private List<WrongNoteEntry> wrongNoteEntries = new ArrayList<>();
+
+    /**
+     * 닉네임 변경
+     */
+    public void changeNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
+
+    /**
+     * 비밀번호 변경 (암호화 로직 포함)
+     */
+    public void changePassword(String newPassword, PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(newPassword);
+    }
+
+    // == 연관 관계 편의 메서드 == //
+
+    public void addChapter(Chapter chapter) {
+        //  User의 chapters 컬렉션에 Chapter를 추가
+        if (!this.chapters.contains(chapter)) { // 이미 포함되어 있는지 확인하여 무한 루프 방지
+            this.chapters.add(chapter);
+        }
+        // 2. Chapter의 user 필드에 User를 설정 (Chapter.setUser() 호출)
+        //    이때 Chapter.setUser() 내부에서 다시 User.addChapter()를 호출하지 않도록 방지 로직 필요
+        if (chapter.getUser() != this) { // Chapter가 아직 이 User를 참조하고 있지 않다면
+            chapter.addUser(this); // Chapter가 자신의 user 필드를 설정 (이때 Chapter.setUser의 내부 로직이 중요)
+        }
+    }
+
+    /**
+     * User가 WrongNoteEntry를 추가할 때 사용합니다.
+     */
+
+    public void addWrongNoteEntry(WrongNoteEntry wrongNoteEntry) {
+        if (wrongNoteEntry != null && !this.wrongNoteEntries.contains(wrongNoteEntry)) {
+            // 이 User의 wrongNoteEntries 리스트에 WrongNoteEntry를 추가
+            this.wrongNoteEntries.add(wrongNoteEntry);
+            // WrongNoteEntry가 관계의 주인이므로 WrongNoteEntry 쪽에서도 관계를 설정해줘야 함
+            // WrongNoteEntry의 setUser 메서드 안에서 이 User의 컬렉션에 자신을 추가하는 로직 포함
+            if (wrongNoteEntry.getUser() != this) {
+                wrongNoteEntry.setUser(this);
+            }
+        }
+    }
 }

--- a/src/main/java/com/example/toeicwordtest/domain/word/entity/Word.java
+++ b/src/main/java/com/example/toeicwordtest/domain/word/entity/Word.java
@@ -6,13 +6,11 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 @Entity
 @Table(name = "word")
-@Getter @Setter
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -39,4 +37,30 @@ public class Word {
     @OneToMany(mappedBy = "word", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Builder.Default // Builder 사용 시 초기화 누락 방지
     private List<WrongNoteEntry> wrongNoteEntries = new ArrayList<>();
+
+    // == 연관 관계 편의 메서드 == //
+
+    public void setChapter(Chapter chapter) {
+        if (this.chapter != chapter) {
+            if (this.chapter != null) {
+                this.chapter.getWords().remove(this);
+            }
+            this.chapter = chapter;
+            if (chapter != null) {
+                chapter.getWords().add(this);
+            }
+        }
+    }
+
+    public void addWrongNoteEntry(WrongNoteEntry wrongNoteEntry) {
+        if (wrongNoteEntry != null && !this.wrongNoteEntries.contains(wrongNoteEntry)) {
+            // 이 Word의 wrongNoteEntries 리스트에 WrongNoteEntry를 추가
+            this.wrongNoteEntries.add(wrongNoteEntry);
+            // WrongNoteEntry가 관계의 주인이므로 WrongNoteEntry 쪽에서도 관계를 설정해줘야 함
+            // WrongNoteEntry의 setWord 메서드 안에서 이 Word의 컬렉션에 자신을 추가하는 로직 포함
+            if (wrongNoteEntry.getWord() != this) {
+                wrongNoteEntry.setWord(this);
+            }
+        }
+    }
 }

--- a/src/main/java/com/example/toeicwordtest/domain/word/entity/Word.java
+++ b/src/main/java/com/example/toeicwordtest/domain/word/entity/Word.java
@@ -23,7 +23,7 @@ public class Word {
     @Column(name = "word_id")
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String spelling;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/toeicwordtest/domain/wrongnote/entity/WrongNoteEntry.java
+++ b/src/main/java/com/example/toeicwordtest/domain/wrongnote/entity/WrongNoteEntry.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "wrong_note_entry") // 새로운 테이블 이름
-@Getter @Setter
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -37,4 +37,44 @@ public class WrongNoteEntry {
 
     // 틀린 횟수 등 추가 정보
     // private int wrongCount = 1;
+
+    // == 연관 관계 편의 메서드 == //
+
+    /**
+     * WrongNoteEntry에 User를 설정하고, 양방향 관계의 일관성을 맞춥니다.
+     * @param user 새로운 User 객체
+     */
+    public void setUser(User user) {
+        if (this.user != user) { // 이미 같은 User라면 아무것도 하지 않음 (무한 루프 방지)
+            // 기존 User와의 관계 끊기 (선택 사항: 양방향 제거 로직, 여기서는 보통 변경이 없으니 생략 가능)
+            if (this.user != null) {
+                this.user.getWrongNoteEntries().remove(this);
+            }
+            this.user = user; // 새로운 User로 설정
+
+            // 새로운 User에 자신을 추가 (새로운 User가 null이 아닐 경우)
+            if (user != null) {
+                user.getWrongNoteEntries().add(this);
+            }
+        }
+    }
+
+    /**
+     * WrongNoteEntry에 Word를 설정하고, 양방향 관계의 일관성을 맞춥니다.
+     * @param word 새로운 Word 객체
+     */
+    public void setWord(Word word) {
+        if (this.word != word) { // 이미 같은 Word라면 아무것도 하지 않음 (무한 루프 방지)
+            // 기존 Word와의 관계 끊기
+            if (this.word != null) {
+                this.word.getWrongNoteEntries().remove(this);
+            }
+            this.word = word; // 새로운 Word로 설정
+
+            // 새로운 Word에 자신을 추가 (새로운 Word가 null이 아닐 경우)
+            if (word != null) {
+                word.addWrongNoteEntry(this);
+            }
+        }
+    }
 }


### PR DESCRIPTION
객체 방식과 외래키 방식 사이의 패러다임 불일치로 인해 객체로 만들 경우 방향에 따른 참조를 해줘야 하며 무한루프를 방지해줘야 하는 문제를 발견했고 엔티티에 적용하였음

캡슐화 및 안정성:
모든 엔티티에서 클래스 레벨의 @Setter를 제거하고, User 엔티티에는 의도가 명확한 updateNickname, updatePassword 같은 비즈니스 메서드를 두었습니다. 이는 객체의 상태 변경을 예측 가능하고 안전하게 만듭니다.

연관 관계 편의 메서드:
User, Chapter, Word, WrongNoteEntry 등 모든 엔티티에 양방향 관계의 일관성을 맞춰주는 편의 메서드(addChapter, setUser, addWord, setChapter 등)를 구현했습니다.
이 메서드들은 "주인" 쪽과 "주인이 아닌 쪽"의 관계를 한 번에 설정해주므로, 서비스 로직에서 발생할 수 있는 실수를 원천적으로 방지합니다.

무한 루프 방지:
모든 연관 관계 편의 메서드에 if (this.user != user) 와 같은 방어 코드를 넣어, 메서드가 서로를 계속 호출하는 무한 루프에 빠지지 않도록 안전하게 설계했습니다.

컬렉션 필드 초기화:
@OneToMany, @ManyToMany 같은 컬렉션 필드에 @Builder.Default를 적용하여, 빌더로 객체를 생성할 때 해당 필드가 null이 되지 않고 비어있는 컬렉션으로 안전하게 초기화되도록 했습니다.
